### PR TITLE
add phpunit 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": "^7.0",
-    "phpunit/phpunit": "~6.0||~7.0||~8.0",
+    "phpunit/phpunit": "~6.0||~7.0||~8.0||~9.0",
     "pimple/pimple": "~3.0"
   },
   "autoload": {

--- a/test/Noback/PHPUnitTestServiceContainer/ServiceContainerTest.php
+++ b/test/Noback/PHPUnitTestServiceContainer/ServiceContainerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Noback\PHPUnitTestServiceContainer;
 
 use PHPUnit\Framework\TestCase;
+use Smartschool\Db\DbalConnectionFactory;
 
 final class ServiceContainerTest extends TestCase
 {
@@ -12,17 +13,27 @@ final class ServiceContainerTest extends TestCase
      */
     public function it_calls_setUp_on_all_providers()
     {
-        $serviceProvider1 = $this->prophesize(ServiceProvider::class);
-        $serviceProvider2 = $this->prophesize(ServiceProvider::class);
+        $serviceProvider1 = $this->getMockBuilder(ServiceProvider::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $serviceProvider2 = $this->getMockBuilder(ServiceProvider::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $serviceContainer = new ServiceContainer();
-        $serviceContainer->register($serviceProvider1->reveal());
-        $serviceContainer->register($serviceProvider2->reveal());
+        $serviceContainer->register($serviceProvider1);
+        $serviceContainer->register($serviceProvider2);
+
+        $serviceProvider1->expects(self::once())
+            ->method('setUp')
+            ->with($serviceContainer);
+
+        $serviceProvider2->expects(self::once())
+            ->method('setUp')
+            ->with($serviceContainer);
 
         $serviceContainer->setUp();
-
-        $serviceProvider1->setUp($serviceContainer)->shouldHaveBeenCalled();
-        $serviceProvider2->setUp($serviceContainer)->shouldHaveBeenCalled();
     }
 
     /**
@@ -30,16 +41,28 @@ final class ServiceContainerTest extends TestCase
      */
     public function it_calls_tearDown_on_all_providers()
     {
-        $serviceProvider1 = $this->prophesize(ServiceProvider::class);
-        $serviceProvider2 = $this->prophesize(ServiceProvider::class);
+        $serviceProvider1 = $this
+            ->getMockBuilder(ServiceProvider::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $serviceProvider2 = $this
+            ->getMockBuilder(ServiceProvider::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $serviceContainer = new ServiceContainer();
-        $serviceContainer->register($serviceProvider1->reveal());
-        $serviceContainer->register($serviceProvider2->reveal());
+        $serviceContainer->register($serviceProvider1);
+        $serviceContainer->register($serviceProvider2);
+
+        $serviceProvider1->expects(self::once())
+            ->method('tearDown')
+            ->with($serviceContainer);
+
+        $serviceProvider2->expects(self::once())
+            ->method('tearDown')
+            ->with($serviceContainer);
 
         $serviceContainer->tearDown();
-
-        $serviceProvider1->tearDown($serviceContainer)->shouldHaveBeenCalled();
-        $serviceProvider2->tearDown($serviceContainer)->shouldHaveBeenCalled();
     }
 }


### PR DESCRIPTION
This PR allows PHPUnit 9 to be used. 

I get 2 warnings whilst running the unit-tests because prophesize() is deprecated and will be removed in PHPUnit 10. I could fix these warnings, but this will break the BC (because I would need to include phpspec/prophecy-phpunit as require-dev and this only allows PHPUnit 9).

Please let me know which option you prefer.

If these adjustments suffice, could you please merge and tag a new version, so I can make a PR on matthiasnoback/doctrine-dbal-test-service-provider?